### PR TITLE
Specify endpoint for Buyer Category update

### DIFF
--- a/service/app/db/MySqlBuyerCategoryRepository.scala
+++ b/service/app/db/MySqlBuyerCategoryRepository.scala
@@ -26,4 +26,8 @@ class MySqlBuyerCategoryRepository @Inject()(protected val dbConfigProvider: Dat
     db.run(buyerCategories.drop(offset).take(limit).result)
   }
 
+  override def modify(id: Long, category: BuyerCategory): Future[Int] = {
+    val q = for {c <- buyerCategories if c.id === id} yield c.name
+    db.run(q.update(category.name))
+  }
 }

--- a/service/app/repositories/BuyerCategoryRepository.scala
+++ b/service/app/repositories/BuyerCategoryRepository.scala
@@ -12,4 +12,6 @@ trait BuyerCategoryRepository {
 
   def retrieveAll(offset: Int, limit: Int): Future[Seq[BuyerCategory]]
 
+  def modify(id: Long, category: BuyerCategory): Future[Int]
+
 }

--- a/service/conf/routes
+++ b/service/conf/routes
@@ -204,6 +204,42 @@ GET     /api/users/:id          controllers.Users.retrieveOne(id: Long)
 POST    /api/buyer-categories                           controllers.BuyerCategories.create()
 
 ###
+#  summary: Modifies buyer category
+#  parameters:
+#    - name: id
+#      description: Buyer category id
+#      in: path
+#      type: integer
+#      format: int64
+#      required: true
+#    - name: buyerCategorySpec
+#      description: JSON document containing a Buyer Category specification
+#      in: body
+#      schema:
+#        $ref: '#/definitions/BuyerCategoryRequest'
+#  tags:
+#    - Buyer Categories
+#  responses:
+#    200:
+#      description: Buyer category successfully modified.
+#      schema:
+#        $ref: '#/definitions/BuyerCategoryResponse'
+#    400:
+#      description: Malformed request specified.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+#    404:
+#      description: Action discount doesn't exist.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+#    500:
+#      description: Internal server error occured.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+###
+PUT     /api/buyer-categories/:id                       controllers.BuyerCategories.update(id: Long)
+
+###
 #  summary: Retrieve all buyer categories
 #  parameters:
 #    - name: page[offset]


### PR DESCRIPTION
### Summary:

- Created `modify` method in **Buyer Category repository** along with **MySQL implementation**. 
- Created route in `conf/routes` with **Swagger** spec.
- Exposed endpoint for `Buyer Category` _updating_.