### PR TITLE
Extend Product model with Image URL

### DIFF
--- a/service/app/db/DatabaseSchema.scala
+++ b/service/app/db/DatabaseSchema.scala
@@ -99,7 +99,7 @@ trait DatabaseSchema {
 
   class Products(tag: Tag) extends Table[Product](tag, "products") {
     def * : ProvenShape[Product] = {
-      val props = (id.?, name, categoryId, price, quantity, createdAt, fillStock, status, minQuantity)
+      val props = (id.?, name, imageUrl, categoryId, price, quantity, createdAt, fillStock, status, minQuantity)
 
       props <> (Product.tupled, Product.unapply)
     }
@@ -107,6 +107,8 @@ trait DatabaseSchema {
     def id: Rep[Long] = column[Long]("id", O.PrimaryKey, O.AutoInc)
 
     def name: Rep[String] = column[String]("name")
+
+    def imageUrl: Rep[String] = column[String]("image_url")
 
     def categoryId: Rep[Long] = column[Long]("category")
 

--- a/service/app/domain/Product.scala
+++ b/service/app/domain/Product.scala
@@ -4,6 +4,7 @@ import org.joda.time.DateTime
 
 case class Product(id: Option[Long] = None,
                    name: String,
+                   imageUrl: String,
                    categoryId: Long,
                    price: Double,
                    quantity: Long,

--- a/service/app/hateoas/products.scala
+++ b/service/app/hateoas/products.scala
@@ -8,6 +8,7 @@ package object products {
   import hateoas._
 
   case class ProductRequestAttributes(name: String,
+                                      imageUrl: String,
                                       price: Double,
                                       quantity: Long,
                                       fillStock: Option[Boolean],
@@ -29,6 +30,7 @@ package object products {
       // TODO Fix if `fillStock` and `status` is defined
       Product(
         name = attributes.name,
+        imageUrl = attributes.imageUrl,
         categoryId = categoryRel.id,
         price = attributes.price,
         quantity = attributes.quantity,
@@ -39,6 +41,7 @@ package object products {
   }
 
   case class ProductResponseAttributes(name: String,
+                                       imageUrl: String,
                                        price: Double,
                                        quantity: Long,
                                        createdAt: String,
@@ -57,6 +60,7 @@ package object products {
     def fromDomain(product: Product): ProductResponseData = {
       val attributes = ProductResponseAttributes(
         name = product.name,
+        imageUrl = product.imageUrl,
         price = product.price,
         quantity = product.quantity,
         createdAt = product.createdAt.toString,

--- a/service/conf/evolutions/default/1.sql
+++ b/service/conf/evolutions/default/1.sql
@@ -39,6 +39,7 @@ CREATE TABLE product_categories (
 CREATE TABLE products (
   id              INT NOT NULL AUTO_INCREMENT,
   name            VARCHAR(40) NOT NULL,
+  image_url       VARCHAR(255) NOT NULL DEFAULT "",
   category        INT NOT NULL,
   price           DOUBLE NOT NULL,
   quantity        INT NOT NULL,

--- a/service/conf/swagger.yml
+++ b/service/conf/swagger.yml
@@ -40,6 +40,10 @@ definitions:
         type: string
         description: Name of the product
         example: MacBook Pro 15-inch
+      imageUrl:
+        type: string
+        description: URL to preview product image
+        example: https://store.storeimages.cdn-apple.com/4974/as-images.apple.com/is/image/AppleInc/aos/published/images/T/N7/TN740/TN740
       price:
         type: double
         description: Product price
@@ -63,6 +67,7 @@ definitions:
         example: 4
     required:
       - name
+      - imageUrl
       - price
       - quantity
       - minQuantity
@@ -123,6 +128,10 @@ definitions:
         type: string
         description: Name of the product
         example: MacBook Pro 15-inch
+      imageUrl:
+        type: string
+        description: URL to preview product image
+        example: https://store.storeimages.cdn-apple.com/4974/as-images.apple.com/is/image/AppleInc/aos/published/images/T/N7/TN740/TN740
       price:
         type: double
         description: Product price
@@ -151,6 +160,7 @@ definitions:
     required:
       - name
       - price
+      - imageUrl
       - quantity
       - createdAt
       - fillStock

--- a/service/test/hateoas/ProductRequestSpec.scala
+++ b/service/test/hateoas/ProductRequestSpec.scala
@@ -16,6 +16,7 @@ class ProductRequestSpec extends WordSpecLike with MustMatchers with BeforeAndAf
     "be successfully created with provided request" in {
       val attributes = ProductRequestAttributes(
         name = "test-product",
+        imageUrl = "test-product-image-url",
         price = 21.10,
         quantity = 4,
         fillStock = None,
@@ -40,6 +41,7 @@ class ProductRequestSpec extends WordSpecLike with MustMatchers with BeforeAndAf
 
       ProductRequest(data).toDomain must have(
         'name (attributes.name),
+        'imageUrl (attributes.imageUrl),
         'price (attributes.price),
         'quantity (attributes.quantity),
         'minQuantity (attributes.minQuantity),


### PR DESCRIPTION
### Summary:

- Updated `DatabaseSchem` with `image_url` field.
- Modified `default` evolution.
- Extend `Product` **domain** class with `imageUrl` field. 
- Fixed **Swagger** docs.
- Adapted _tests_ to model change.

Closes #33 with this PR. 