### PR TITLE
Extend product categories retrieval with 'subcategories' relationship

### DIFF
--- a/service/app/db/MySqlProductCategoryRepository.scala
+++ b/service/app/db/MySqlProductCategoryRepository.scala
@@ -22,6 +22,10 @@ class MySqlProductCategoryRepository @Inject()(protected val dbConfigProvider: D
     db.run(productCategories.drop(offset).take(limit).result)
   }
 
+  override def retrieveAllSubcategories(id: Long, offset: Int, limit: Int): Future[Seq[ProductCategory]] = {
+    db.run(productCategories.filter(_.superCategoryId === id).drop(offset).take(limit).result)
+  }
+
   override def modify(id: Long, category: ProductCategory): Future[Int] = {
     val q = for {c <- productCategories if c.id === id} yield (c.name, c.superCategoryId, c.maxDiscount)
     db.run(q.update((category.name, category.superCategoryId, category.maxDiscount)))

--- a/service/app/hateoas/product_categories.scala
+++ b/service/app/hateoas/product_categories.scala
@@ -2,7 +2,7 @@ package hateoas
 
 import commons.CollectionLinks
 import domain.ProductCategory
-import relationships.{RelationshipData, RelationshipLinks, RequestRelationship, ResponseRelationship}
+import relationships._
 
 package object product_categories {
 
@@ -24,27 +24,34 @@ package object product_categories {
     }
   }
 
-  case class ProductCategoryResponseRelationships(superCategory: ResponseRelationship)
+  case class ProductCategoryResponseRelationships(superCategory: Option[ResponseRelationship], subcategories: ResponseRelationshipCollection)
 
-  case class ProductCategoryResponseData(id: Long, `type`: String, attributes: ProductCategoryAttributes, relationships: Option[ProductCategoryResponseRelationships])
+  case class ProductCategoryResponseData(id: Long, `type`: String, attributes: ProductCategoryAttributes, relationships: ProductCategoryResponseRelationships)
 
   object ProductCategoryResponseData {
     def fromDomain(category: ProductCategory): ProductCategoryResponseData = {
-      val relationships =
+      val superCategoryRelationship =
         if (category.superCategoryId.isDefined)
-          Some(ProductCategoryResponseRelationships(
-            superCategory = ResponseRelationship(
-              data = RelationshipData(
-                `type` = ProductCategories,
-                id = category.superCategoryId.get
-              ),
-              links = RelationshipLinks(
-                related = s"api/product-categories/${category.superCategoryId.get}"
-              )
+          Some(ResponseRelationship(
+            data = RelationshipData(
+              `type` = ProductCategories,
+              id = category.superCategoryId.get
+            ),
+            links = RelationshipLinks(
+              related = s"api/product-categories/${category.superCategoryId.get}"
             )
           ))
-        else
-          None
+        else None
+
+      val relationships =
+        ProductCategoryResponseRelationships(
+          superCategory = superCategoryRelationship,
+          subcategories = ResponseRelationshipCollection(
+            links = RelationshipLinks(
+              related = s"api/product-categories/${category.id.get}/subcategories"
+            )
+          )
+        )
 
       ProductCategoryResponseData(
         id = category.id.get,

--- a/service/app/repositories/ProductCategoryRepository.scala
+++ b/service/app/repositories/ProductCategoryRepository.scala
@@ -10,6 +10,8 @@ trait ProductCategoryRepository {
 
   def retrieveAll(offset: Int, limit: Int): Future[Seq[ProductCategory]]
 
+  def retrieveAllSubcategories(id: Long, offset: Int, limit: Int): Future[Seq[ProductCategory]]
+
   def modify(id: Long, category: ProductCategory): Future[Int]
 
   def findOne(id: Long): Future[Option[ProductCategory]]

--- a/service/conf/routes
+++ b/service/conf/routes
@@ -751,6 +751,49 @@ POST    /api/product-categories             controllers.ProductCategories.create
 GET     /api/product-categories             controllers.ProductCategories.retrieveAll(`page[offset]`: Int ?= 0, `page[limit]`: Int ?= 10)
 
 ###
+#  summary: Retrieve all subcategories of specified product category
+#  parameters:
+#    - name: id
+#      description: Identifier of root product category.
+#      in: path
+#      type: long
+#      format: int64
+#      required: true
+#    - name: page[offset]
+#      description: Identifier of a position to start retrieving items from.
+#      in: query
+#      type: integer
+#      default: 0
+#      required: false
+#    - name: page[limit]
+#      description: Maximum number of items to retrieve.
+#      in: query
+#      type: integer
+#      default: 10
+#      required: false
+#  tags:
+#    - Product Categories
+#  responses:
+#    200:
+#      description: Product subcategories successfully retrieved.
+#      schema:
+#        $ref: '#/definitions/ProductCategoryCollectionResponse'
+#    400:
+#      description: Malformed request specified.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+#    404:
+#      description: Product category doesn't exist.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+#    500:
+#      description: Internal server error occured.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+###
+GET     /api/product-categories/:id/subcategories           controllers.ProductCategories.retrieveAllSubcategories(id: Long, `page[offset]`: Int ?= 0, `page[limit]`: Int ?= 10)
+
+###
 #  summary: Modifies product category
 #  parameters:
 #    - name: id

--- a/service/conf/swagger.yml
+++ b/service/conf/swagger.yml
@@ -833,12 +833,18 @@ definitions:
       - type
       - id
       - attributes
+      - relationships
   ProductCategoryResponseRelationships:
     type: object
     properties:
       superCategory:
         description: Relationship to super category
         $ref: '#/definitions/ResponseRelationship'
+      subcategories:
+        description: Relationship to list of subcategories
+        $ref: '#/definitions/ResponseRelationshipCollection'
+    required:
+      - subcategories
   ProductCategoryAttributes:
     type: object
     properties:


### PR DESCRIPTION
### Summary:

- Support retrieving **subcategories** of specified **product category**.
- Exposed endpoint for r**etrieving subcategories**. 
- Modified **Swagger** docs.
- Created `ProductCategoryRepository` method for **subcategories retrieving** along with **MySQL** implementation. 
- Updated `product categories` **JSON API**.

Closes #35 with this PR.