### PR TITLE
Extend Product Category model with consumer goods flag

### DIFF
--- a/service/app/db/DatabaseSchema.scala
+++ b/service/app/db/DatabaseSchema.scala
@@ -81,7 +81,7 @@ trait DatabaseSchema {
 
   class ProductCategories(tag: Tag) extends Table[ProductCategory](tag, "product_categories") {
     def * : ProvenShape[ProductCategory] = {
-      val props = (id.?, name, superCategoryId, maxDiscount)
+      val props = (id.?, name, superCategoryId, maxDiscount, isConsumerGoods)
 
       props <> (ProductCategory.tupled, ProductCategory.unapply)
     }
@@ -93,6 +93,8 @@ trait DatabaseSchema {
     def superCategoryId: Rep[Option[Long]] = column[Option[Long]]("super_category")
 
     def maxDiscount: Rep[Double] = column[Double]("max_discount")
+
+    def isConsumerGoods: Rep[Boolean] = column[Boolean]("is_consumer_goods")
 
     def superCategory: ForeignKeyQuery[ProductCategories, ProductCategory] = foreignKey("super_category_fk", superCategoryId, productCategories)(_.id.?)
   }

--- a/service/app/domain/ProductCategory.scala
+++ b/service/app/domain/ProductCategory.scala
@@ -3,4 +3,5 @@ package domain
 case class ProductCategory(id: Option[Long] = None,
                            name: String,
                            superCategoryId: Option[Long] = None,
-                           maxDiscount: Double)
+                           maxDiscount: Double,
+                           isConsumerGoods: Boolean = false)

--- a/service/app/hateoas/JsonApi.scala
+++ b/service/app/hateoas/JsonApi.scala
@@ -38,10 +38,11 @@ object JsonApi {
   implicit val prodRes: OFormat[ProductResponse] = Json.format[ProductResponse]
   implicit val prodResCollection: OFormat[ProductCollectionResponse] = Json.format[ProductCollectionResponse]
 
-  implicit val prodCatAttrs: OFormat[ProductCategoryAttributes] = Json.format[ProductCategoryAttributes]
+  implicit val prodCatReqAttrs: OFormat[ProductCategoryRequestAttributes] = Json.format[ProductCategoryRequestAttributes]
   implicit val prodCatReqRels: OFormat[ProductCategoryRequestRelationships] = Json.format[ProductCategoryRequestRelationships]
   implicit val prodCatReqData: OFormat[ProductCategoryRequestData] = Json.format[ProductCategoryRequestData]
   implicit val prodCatReq: OFormat[ProductCategoryRequest] = Json.format[ProductCategoryRequest]
+  implicit val prodCatResAttrs: OFormat[ProductCategoryResponseAttributes] = Json.format[ProductCategoryResponseAttributes]
   implicit val prodCatResRels: OFormat[ProductCategoryResponseRelationships] = Json.format[ProductCategoryResponseRelationships]
   implicit val prodCatResData: OFormat[ProductCategoryResponseData] = Json.format[ProductCategoryResponseData]
   implicit val prodCatRes: OFormat[ProductCategoryResponse] = Json.format[ProductCategoryResponse]

--- a/service/app/hateoas/product_categories.scala
+++ b/service/app/hateoas/product_categories.scala
@@ -6,11 +6,11 @@ import relationships._
 
 package object product_categories {
 
-  case class ProductCategoryAttributes(name: String, maxDiscount: Double)
+  case class ProductCategoryRequestAttributes(name: String, maxDiscount: Double, isConsumerGoods: Option[Boolean])
 
   case class ProductCategoryRequestRelationships(superCategory: RequestRelationship)
 
-  case class ProductCategoryRequestData(`type`: String, attributes: ProductCategoryAttributes, relationships: Option[ProductCategoryRequestRelationships])
+  case class ProductCategoryRequestData(`type`: String, attributes: ProductCategoryRequestAttributes, relationships: Option[ProductCategoryRequestRelationships])
 
   case class ProductCategoryRequest(data: ProductCategoryRequestData) {
     def toDomain: ProductCategory = {
@@ -19,14 +19,17 @@ package object product_categories {
       ProductCategory(
         name = attributes.name,
         maxDiscount = attributes.maxDiscount,
+        isConsumerGoods = if (attributes.isConsumerGoods.isDefined) attributes.isConsumerGoods.get else false,
         superCategoryId = if (data.relationships.isDefined) Some(data.relationships.get.superCategory.data.id) else None
       )
     }
   }
 
+  case class ProductCategoryResponseAttributes(name: String, maxDiscount: Double, isConsumerGoods: Boolean)
+
   case class ProductCategoryResponseRelationships(superCategory: Option[ResponseRelationship], subcategories: ResponseRelationshipCollection)
 
-  case class ProductCategoryResponseData(id: Long, `type`: String, attributes: ProductCategoryAttributes, relationships: ProductCategoryResponseRelationships)
+  case class ProductCategoryResponseData(id: Long, `type`: String, attributes: ProductCategoryResponseAttributes, relationships: ProductCategoryResponseRelationships)
 
   object ProductCategoryResponseData {
     def fromDomain(category: ProductCategory): ProductCategoryResponseData = {
@@ -56,9 +59,10 @@ package object product_categories {
       ProductCategoryResponseData(
         id = category.id.get,
         `type` = ProductCategories,
-        attributes = ProductCategoryAttributes(
+        attributes = ProductCategoryResponseAttributes(
           name = category.name,
-          maxDiscount = category.maxDiscount
+          maxDiscount = category.maxDiscount,
+          isConsumerGoods = category.isConsumerGoods
         ),
         relationships = relationships
       )

--- a/service/conf/evolutions/default/1.sql
+++ b/service/conf/evolutions/default/1.sql
@@ -27,10 +27,11 @@ CREATE TABLE users (
 );
 
 CREATE TABLE product_categories (
-  id              INT NOT NULL AUTO_INCREMENT,
-  name            VARCHAR(40) NOT NULL,
-  super_category  INT NULL,
-  max_discount    DOUBLE NOT NULL,
+  id                INT NOT NULL AUTO_INCREMENT,
+  name              VARCHAR(40) NOT NULL,
+  super_category    INT NULL,
+  max_discount      DOUBLE NOT NULL,
+  is_consumer_goods BOOLEAN NOT NULL DEFAULT FALSE,
 
   PRIMARY KEY (id)
   -- FOREIGN KEY (super_category) REFERENCES product_categories(super_category)

--- a/service/conf/swagger.yml
+++ b/service/conf/swagger.yml
@@ -877,12 +877,30 @@ definitions:
           - product-categories
         description: Type of requested Product Category
       attributes:
-        $ref: '#/definitions/ProductCategoryAttributes'
+        $ref: '#/definitions/ProductCategoryRequestAttributes'
       relationships:
         $ref: '#/definitions/ProductCategoryRequestRelationships'
     required:
       - type
       - attributes
+  ProductCategoryRequestAttributes:
+    type: object
+    properties:
+      name:
+        type: string
+        description: General product category
+        example: Electronics
+      maxDiscount:
+        type: double
+        description: Maximum allowed discount for product in specified category
+        example: 20
+      isConsumerGoods:
+        type: boolean
+        description: Represents flag if product category is consumer goods
+        default: false
+    required:
+      - name
+      - maxDiscount
   ProductCategoryRequestRelationships:
     type: object
     properties:
@@ -925,7 +943,7 @@ definitions:
         description: Unique identifier of Product category
         example: 1
       attributes:
-        $ref: '#/definitions/ProductCategoryAttributes'
+        $ref: '#/definitions/ProductCategoryResponseAttributes'
       relationships:
         $ref: '#/definitions/ProductCategoryResponseRelationships'
     required:
@@ -933,6 +951,24 @@ definitions:
       - id
       - attributes
       - relationships
+  ProductCategoryResponseAttributes:
+    type: object
+    properties:
+      name:
+        type: string
+        description: General product category
+        example: Electronics
+      maxDiscount:
+        type: double
+        description: Maximum allowed discount for product in specified category
+        example: 20
+      isConsumerGoods:
+        type: boolean
+        description: Represents flag if product category is consumer goods
+    required:
+      - name
+      - maxDiscount
+      - isConsumerGoods
   ProductCategoryResponseRelationships:
     type: object
     properties:
@@ -944,20 +980,6 @@ definitions:
         $ref: '#/definitions/ResponseRelationshipCollection'
     required:
       - subcategories
-  ProductCategoryAttributes:
-    type: object
-    properties:
-      name:
-        type: string
-        description: General product category
-        example: Electronics
-      maxDiscount:
-        type: double
-        description: Maximum allowed discount for product in specified category
-        example: 20
-    required:
-      - name
-      - maxDiscount
   ActionDiscountRequest:
     type: object
     properties:


### PR DESCRIPTION
### Summary:

- Added field `isConsumerGoods` flag to `ProductCategory` domain.
- Modify **JSON API** `request` and `response` classes regarding to domain change. 
- Updated **database schema** along with `default` evolution.
- Fix **Swagger** docs.