### PR TITLE
Extend order with address field

### DIFF
--- a/service/app/db/DatabaseSchema.scala
+++ b/service/app/db/DatabaseSchema.scala
@@ -146,7 +146,7 @@ trait DatabaseSchema {
 
   class Bills(tag: Tag) extends Table[Bill](tag, "bills") {
     def * : ProvenShape[Bill] = {
-      val props = (id.?, createdAt, customer, state, totalItems, amount, discount, discountAmount, pointsSpent, pointsGained)
+      val props = (id.?, createdAt, customer, state, totalItems, amount, discount, discountAmount, pointsSpent, pointsGained, address, longitude, latitude)
 
       props <> (Bill.tupled, Bill.unapply)
     }
@@ -174,6 +174,12 @@ trait DatabaseSchema {
     def pointsSpent: Rep[Long] = column[Long]("points_spent")
 
     def pointsGained: Rep[Long] = column[Long]("points_gained")
+
+    def address: Rep[Option[String]] = column[Option[String]]("address")
+
+    def longitude: Rep[Option[Double]] = column[Option[Double]]("longitude")
+
+    def latitude: Rep[Option[Double]] = column[Option[Double]]("latitude")
   }
 
   class BillItems(tag: Tag) extends Table[BillItem](tag, "bill_items") {

--- a/service/app/domain/Bill.scala
+++ b/service/app/domain/Bill.scala
@@ -2,13 +2,18 @@ package domain
 
 import org.joda.time.DateTime
 
-case class Bill(id: Option[Long] = None,
-                createdAt: DateTime,
-                customerId: Long,
-                state: BillState,
-                totalItems: Long,
-                amount: Double,
-                discount: Double,
-                discountAmount: Double,
-                pointsSpent: Long,
-                pointsGained: Long)
+case class Bill(
+    id: Option[Long] = None,
+    createdAt: DateTime,
+    customerId: Long,
+    state: BillState,
+    totalItems: Long,
+    amount: Double,
+    discount: Double,
+    discountAmount: Double,
+    pointsSpent: Long,
+    pointsGained: Long,
+    address: Option[String] = None,
+    longitude: Option[Double] = None,
+    latitude: Option[Double] = None
+)

--- a/service/app/hateoas/bills.scala
+++ b/service/app/hateoas/bills.scala
@@ -11,11 +11,13 @@ package object bills {
 
   case class BillRequestRelationships(customer: RequestRelationship)
 
-  case class BillRequestData(`type`: String, attributes: BillRequestAttributes, relationships: BillRequestRelationships)
+  case class BillRequestData(`type`: String,
+                             attributes: BillRequestAttributes,
+                             relationships: BillRequestRelationships)
 
   case class BillRequest(data: BillRequestData) {
     def toDomain: Bill = {
-      val attributes = data.attributes
+      val attributes    = data.attributes
       val relationships = data.relationships
 
       Bill(
@@ -32,18 +34,28 @@ package object bills {
     }
   }
 
-  case class BillResponseAttributes(createdAt: String,
-                                    state: String,
-                                    totalItems: Long,
-                                    amount: Double,
-                                    discount: Double,
-                                    discountAmount: Double,
-                                    pointsGained: Long,
-                                    pointsSpent: Long)
+  case class BillResponseAttributes(
+      createdAt: String,
+      state: String,
+      totalItems: Long,
+      amount: Double,
+      discount: Double,
+      discountAmount: Double,
+      pointsGained: Long,
+      pointsSpent: Long,
+      address: Option[String],
+      longitude: Option[Double],
+      latitude: Option[Double]
+  )
 
-  case class BillResponseRelationships(customer: ResponseRelationship, items: ResponseRelationshipCollection, discounts: ResponseRelationshipCollection)
+  case class BillResponseRelationships(customer: ResponseRelationship,
+                                       items: ResponseRelationshipCollection,
+                                       discounts: ResponseRelationshipCollection)
 
-  case class BillResponseData(`type`: String, id: Long, attributes: BillResponseAttributes, relationships: BillResponseRelationships)
+  case class BillResponseData(`type`: String,
+                              id: Long,
+                              attributes: BillResponseAttributes,
+                              relationships: BillResponseRelationships)
 
   object BillResponseData {
     def fromDomain(bill: Bill): BillResponseData = {
@@ -55,18 +67,20 @@ package object bills {
         discount = bill.discount,
         discountAmount = bill.discountAmount,
         pointsGained = bill.pointsGained,
-        pointsSpent = bill.pointsSpent
+        pointsSpent = bill.pointsSpent,
+        address = bill.address,
+        longitude = bill.longitude,
+        latitude = bill.latitude
       )
 
       val relationships = BillResponseRelationships(
-        customer = ResponseRelationship(
-          links = RelationshipLinks(
-            related = s"/api/users/${bill.customerId}"
-          ),
-          data = RelationshipData(
-            `type` = UsersType,
-            id = bill.customerId
-          )),
+        customer = ResponseRelationship(links = RelationshipLinks(
+                                          related = s"/api/users/${bill.customerId}"
+                                        ),
+                                        data = RelationshipData(
+                                          `type` = UsersType,
+                                          id = bill.customerId
+                                        )),
         items = ResponseRelationshipCollection(
           links = RelationshipLinks(
             related = s"/api/users/${bill.customerId}/bills/${bill.id.get}/bill-items"
@@ -91,7 +105,8 @@ package object bills {
   case class BillResponse(data: BillResponseData)
 
   object BillResponse {
-    def fromDomain(bill: Bill): BillResponse = BillResponse(data = BillResponseData.fromDomain(bill))
+    def fromDomain(bill: Bill): BillResponse =
+      BillResponse(data = BillResponseData.fromDomain(bill))
   }
 
   case class BillCollectionResponse(data: Seq[BillResponseData], links: CollectionLinks)

--- a/service/conf/evolutions/default/4.sql
+++ b/service/conf/evolutions/default/4.sql
@@ -1,0 +1,11 @@
+# --- !Ups
+
+ALTER TABLE bills ADD COLUMN address TEXT;
+ALTER TABLE bills ADD COLUMN longitude DOUBLE;
+ALTER TABLE bills ADD COLUMN latitude DOUBLE;
+
+# --- !Downs
+
+ALTER TABLE bills DROP COLUMN address;
+ALTER TABLE bills DROP COLUMN longitude;
+ALTER TABLE bills DROP COLUMN latitude;

--- a/service/conf/routes
+++ b/service/conf/routes
@@ -245,7 +245,30 @@ POST    /api/users               controllers.Users.registerUser()
 ###
 POST    /api/users/auth         controllers.Users.auth()
 
-
+###
+#  summary: Authenticate user via Google
+#  parameters:
+#    - name: googleAuthSpec
+#      description: JSON document containing a GoogleAuth specification
+#      in: body
+#      schema:
+#        $ref: '#/definitions/GoogleAuthRequest'
+#  tags:
+#    - Users
+#  responses:
+#    200:
+#      description: Successfully retrieved Google's response.
+#      schema:
+#        $ref: '#/definitions/GoogleAuthResponse'
+#    400:
+#      description: Malformed JSON specified.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+#    500:
+#      description: Internal server error occured.
+#      schema:
+#        $ref: '#/definitions/ErrorResponse'
+###
 POST    /api/auth/google        controllers.Users.googleAuth()
 
 ###

--- a/service/conf/swagger.yml
+++ b/service/conf/swagger.yml
@@ -382,6 +382,44 @@ definitions:
       - address
       - longitude
       - latitude
+  GoogleAuthRequest:
+    type: object
+    properties:
+      idToken:
+        type: string
+        description: Google token obtained from personal address
+    required:
+      - idToken
+  GoogleAuthResponse:
+    type: object
+    properties:
+      aud:
+        type: string
+      sub:
+        type: string
+      email:
+        type: string
+        description: User's Google email
+      email_verified:
+        type: string
+        description: Whether is email verified or not
+      picture:
+        type: string
+        description: Picture used on Google's account
+      given_name:
+        type: string
+        description: Given name of the user
+      family_name:
+        type: string
+        description: Family name of the user
+    required:
+      - aud
+      - sub
+      - email
+      - email_verified
+      - picture
+      - given_name
+      - family_name
   BuyerCategoryRequest:
     type: object
     properties:

--- a/service/conf/swagger.yml
+++ b/service/conf/swagger.yml
@@ -742,6 +742,18 @@ definitions:
         format: int64
         description: Total spent points in shopping
         example: 10
+      address:
+        type: string
+        description: Address of the current order location
+        example: Pozorišni trg 6
+      longitude:
+        type: double
+        description: Location longitude
+        example: 45.26
+      latitude:
+        type: double
+        description: Location latitude
+        example: 19.83
     required:
       - createdAt
       - state


### PR DESCRIPTION
### Summary:

- Provided **Swagger docs** for `GoogleAuth` endpoint
- Extend `Bill` table with optional `address` field